### PR TITLE
Corrected dependency on pyzmq in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     package_dir={'': 'lib'},
     py_modules=['zmqc'],
     install_requires=[
+        'pyzmq<3',
         'argparse>=1.2.1',
     ],
     entry_points={


### PR DESCRIPTION
installing zmqc when having pyzmq 13.0 installed results in failing runs (when the connection shall be established, some call with sockets complains as missing some funciton).

setup.py got added dependency to pyzmq and this is restricted to version 2.\* (<3.*)

Note: this wil not imporive situation, if you install zmqc into system with already upgraded pyzmqc. In such a case, you may use command builout:

$ buildout init zmqc

Which shall install zmqc into clean directory.
