### PR TITLE
Resolved problem with import of int_sockopts which were moved from core to sugar

### DIFF
--- a/lib/zmqc.py
+++ b/lib/zmqc.py
@@ -222,11 +222,15 @@ def get_sockopts(sock_opts):
         zmqc.ParserError: Unrecognised socket option: 'NONEXISTENTOPTION'
 
     """
+    try:
+        import zmq.sugar as optslib
+    except:
+        import zmq.core.constants as optslib
 
     option_coerce = {
-        int: set(zmq.core.constants.int_sockopts).union(
-            zmq.core.constants.int64_sockopts),
-        str: set(zmq.core.constants.bytes_sockopts)
+        int: set(optslib.int_sockopts).union(
+            optslib.int64_sockopts),
+        str: set(optslib.bytes_sockopts)
     }
 
     options = []

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 from distribute_setup import use_setuptools
 use_setuptools()
 
-from setuptools import setup, find_packages
+from setuptools import setup
 import os.path as p
 
 VERSION = open(p.join(p.dirname(p.abspath(__file__)), 'VERSION')).read().strip()
@@ -19,7 +19,7 @@ setup(
     package_dir={'': 'lib'},
     py_modules=['zmqc'],
     install_requires=[
-        'pyzmq<3',
+        'pyzmq',
         'argparse>=1.2.1',
     ],
     entry_points={


### PR DESCRIPTION
With pyzmq 13.*, int_socopts were moved from zmq.core.constants to zmq.sugar

This caused failure to run if the system contained newer version of pyzmq.
