### PR TITLE
s/zmq.core.constants/zmq.constants

### DIFF
--- a/lib/zmqc.py
+++ b/lib/zmqc.py
@@ -225,7 +225,7 @@ def get_sockopts(sock_opts):
     try:
         import zmq.sugar as optslib
     except:
-        import zmq.core.constants as optslib
+        import zmq.constants as optslib
 
     option_coerce = {
         int: set(optslib.int_sockopts).union(


### PR DESCRIPTION
I think that `zmq.core.constants` was only available in old releases of pyzmq. This PR fixes the import statement.
